### PR TITLE
Add Chitin: AI agent identity with Arweave permanent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ _This list is for projects, tools, or pretty much any things related to Arweave 
 
 ## Apps 🕯️
 
+- [Chitin](https://chitin.id) - On-chain soul identity for AI agents. Uses Arweave for immutable genesis records and versioned chronicles (growth records), with Soulbound Tokens on Base L2. Live on Base Mainnet.
 - [Alex](https://alex.arweave.dev/) - Preserving Human History
 - [Akord](https://akord.com/) - Permanent blockchain storage for the things that matter most.
 - [ArNS](https://arweave.dev/) - Arweave Name System (ArNS)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _This list is for projects, tools, or pretty much any things related to Arweave 
 
 ## Apps 🕯️
 
-- [Chitin](https://chitin.id) - On-chain soul identity for AI agents. Uses Arweave for immutable genesis records and versioned chronicles (growth records), with Soulbound Tokens on Base L2. Live on Base Mainnet.
+- [Chitin](https://chitin.id) - On-chain soul identity for AI agents. Uses Arweave for immutable genesis records and versioned chronicles (growth records), with Soulbound Tokens on Base L2. Live on Base Mainnet. ([GitHub](https://github.com/Tiida-Tech/chitin-contracts))
 - [Alex](https://alex.arweave.dev/) - Preserving Human History
 - [Akord](https://akord.com/) - Permanent blockchain storage for the things that matter most.
 - [ArNS](https://arweave.dev/) - Arweave Name System (ArNS)


### PR DESCRIPTION
Adds [Chitin](https://chitin.id) to the Apps section.

Chitin uses Arweave for immutable genesis records and versioned chronicles (growth records) for AI agents, with Soulbound Tokens on Base L2. Live on Base Mainnet.